### PR TITLE
📖 add info about ResizeObservers

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,55 @@ function MyComponent() {
   )
 }
 ```
+
+## ResizeObserver
+
+[Resize Observer](https://developers.google.com/web/updates/2016/10/resizeobserver)
+is the API is used to determine if an element is resized. Browser support is pretty good in Chrome, but is still missing support in other major browsers.
+
+> [Can i use ResizeObserver?](https://caniuse.com/#feat=ResizeObserver)
+
+### Polyfill
+
+You can import the
+[polyfill](https://github.com/que-etc/resize-observer-polyfill) directly from here
+
+```sh
+yarn add resize-observer-polyfill
+```
+
+Then import it in your app:
+
+```js
+import 'resize-observer-polyfill'
+```
+
+If you are using Webpack (or similar) you could use [dynamic
+imports](https://webpack.js.org/api/module-methods/#import-), to load the
+Polyfill only if needed. A basic implementation could look something like this:
+
+```js
+loadPolyfills()
+  .then(() => /* Render React application now that your Polyfills are ready */)
+
+/**
+* Do feature detection, to figure out which polyfills needs to be imported.
+**/
+function loadPolyfills() {
+  const polyfills = []
+
+  if (!supportsResizeObserver()) {
+    polyfills.push(import('resize-observer-polyfill'))
+  }
+
+  return Promise.all(polyfills)
+}
+
+function supportsResizeObserver() {
+  return (
+    'ResizeObserver' in global &&
+    'ResizeObserverEntry' in global &&
+    'contentRect' in ResizeObserverEntry.prototype
+  )
+}
+```


### PR DESCRIPTION
This PR includes some information about loading polyfills with webpack or directly by importing polyfill code and includes some links to caniuse and google docs.

Feel free to close if you don't find helpful.