### PR TITLE
stops from breaking in browsers that dont support resizeobserver

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ function useComponentSize(ref) {
   useLayoutEffect(() => {
     handleResize()
 
-    if (ResizeObserver) {
+    if (window.ResizeObserver) {
       let resizeObserver = new ResizeObserver(() => handleResize())
       resizeObserver.observe(ref.current)
 


### PR DESCRIPTION
<img width="534" alt="screen shot 2018-11-13 at 01 50 02" src="https://user-images.githubusercontent.com/29547922/48385455-826f5100-e6e6-11e8-8086-57a3cca5e167.png">
