### PR TITLE
TypeScript: constraint ref to element

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,4 +3,4 @@ interface ComponentSize {
   height: number
 }
 
-export default function useComponentSize(ref: React.RefObject<HTMLElement>): ComponentSize
+export default function useComponentSize(ref: React.RefObject<Element>): ComponentSize

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,4 +3,4 @@ interface ComponentSize {
   height: number
 }
 
-export default function useComponentSize<T = any>(ref: React.RefObject<T>): ComponentSize
+export default function useComponentSize(ref: React.RefObject<HTMLElement>): ComponentSize


### PR DESCRIPTION
Previously this would not error at compile time:

``` ts
import useComponentSize from '@rehooks/component-size';
import React = require('react');

declare const ref: React.RefObject<{ foo: 1 }>;
// No error
useComponentSize(ref);
```

With this change, it does.

`useComponentSize` always expects the ref to contain a HTML element, so it can reliably extract size/dimensions.