### PR TITLE
resize observer option 

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,4 +3,8 @@ interface ComponentSize {
   height: number
 }
 
-export default function useComponentSize<T = any>(ref: React.RefObject<T>): ComponentSize
+interface ComponentSizeOptions {
+  ResizeObserver?: ResizeObserver;
+}
+
+export default function useComponentSize<T = any>(ref: React.RefObject<T>, opts?: ComponentSizeOptions): ComponentSize

--- a/index.js
+++ b/index.js
@@ -18,7 +18,12 @@ function getSize(el) {
   }
 }
 
-function useComponentSize(ref) {
+function useComponentSize(ref, opts) {
+  var ResizeObserverConstructor = opts && opts.ResizeObserver
+    ? opts.ResizeObserver
+    : typeof ResizeObserver === 'function'
+      ? ResizeObserver
+      : undefined;
   var _useState = useState(getSize(ref ? ref.current : {}))
   var ComponentSize = _useState[0]
   var setComponentSize = _useState[1]
@@ -40,8 +45,8 @@ function useComponentSize(ref) {
 
       handleResize()
 
-      if (typeof ResizeObserver === 'function') {
-        var resizeObserver = new ResizeObserver(function() {
+      if (ResizeObserverConstructor) {
+        var resizeObserver = new ResizeObserverConstructor(function() {
           handleResize()
         })
         resizeObserver.observe(ref.current)

--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ function useComponentSize(ref, opts) {
         }
       }
     },
-    [ref.current]
+    [ref.current, ResizeObserverConstructor]
   )
 
   return ComponentSize

--- a/index.js.flow
+++ b/index.js.flow
@@ -3,4 +3,8 @@ interface ComponentSize {
   height: number,
 }
 
-declare export default function useComponentSize<T>(ref: React.Ref<T>): ComponentSize;
+interface ComponentSizeOptions {
+  ResizeObserver?: ResizeObserver;
+}
+
+declare export default function useComponentSize<T>(ref: React.Ref<T>, opts?: ComponentSizeOptions): ComponentSize;

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "raf": "3.4.0",
     "react": "16.8.1",
     "react-dom": "16.8.1",
-    "react-test-renderer": "16.8.1"
+    "react-test-renderer": "16.8.1",
+    "resize-observer-polyfill": "^1.5.1"
   },
   "ava": {
     "require": [


### PR DESCRIPTION
Closes #26 
Closes #24 

- I am unsure if the flow type is correct since I don’t use flow 
- I added `resize-observer-polyfill` as a dev dep since it's bundled with flow and typescript typings for ResizeObserver to use (it’s not available in the standard TypeScript libs since it’s still not a confirmed spec yet), though can just inline those if we don't want to include it as a dep

still ensuring this works locally, having some issues with  getting it to lazy load as in the readme changes i made

EDIT: it does work, just need to wrap the set state call in a function; `ResizeObserver` is a function so `setState()` interprets it as a state reducer, which is not what we're trying to achieve. fixing the README

EDIT 2: done