### PR TITLE
fix: add missing bugs metadata field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@rehooks/component-size",
   "version": "1.0.3",
+  "homepage": "https://github.com/rehooks/component-size",
+  "bugs": {
+    "url": "https://github.com/rehooks/component-size/issues"
+  },
   "description": "React hook for component-size",
   "main": "index.js",
   "repository": "https://github.com/rehooks/component-size",


### PR DESCRIPTION
Adds missing package metadata fields to `package.json`.

This allows npm tooling and consumers to correctly resolve package metadata.